### PR TITLE
Rename Country to CPVCountry to avoid conflicts

### DIFF
--- a/CountryPickerView/CountryPickerView.swift
+++ b/CountryPickerView/CountryPickerView.swift
@@ -13,7 +13,7 @@ public enum SearchBarPosition {
     case tableViewHeader, navigationBar, hidden
 }
 
-public struct Country {
+public struct CPVCountry {
    public var name: String
    public var code: String
    public var phoneCode: String
@@ -29,10 +29,10 @@ public struct Country {
     }
 }
 
-public func ==(lhs: Country, rhs: Country) -> Bool {
+public func ==(lhs: CPVCountry, rhs: CPVCountry) -> Bool {
     return lhs.code == rhs.code
 }
-public func !=(lhs: Country, rhs: Country) -> Bool {
+public func !=(lhs: CPVCountry, rhs: CPVCountry) -> Bool {
     return lhs.code != rhs.code
 }
 
@@ -81,8 +81,8 @@ public class CountryPickerView: NibView {
     weak public var dataSource: CountryPickerViewDataSource?
     weak public var delegate: CountryPickerViewDelegate?
     
-    fileprivate var _selectedCountry: Country?
-    internal(set) public var selectedCountry: Country {
+    fileprivate var _selectedCountry: CPVCountry?
+    internal(set) public var selectedCountry: CPVCountry {
         get {
             return _selectedCountry
                 ?? countries.first(where: { $0.code == Locale.current.regionCode })
@@ -149,8 +149,8 @@ public class CountryPickerView: NibView {
         }
     }
     
-    public var countries: [Country] = {
-        var countries = [Country]()
+    public var countries: [CPVCountry] = {
+        var countries = [CPVCountry]()
         let bundle = Bundle(for: CountryPickerView.self)
         guard let jsonPath = bundle.path(forResource: "CountryPickerView.bundle/Data/CountryCodes", ofType: "json"),
             let jsonData = try? Data(contentsOf: URL(fileURLWithPath: jsonPath)) else {
@@ -172,7 +172,7 @@ public class CountryPickerView: NibView {
                         continue
                 }
                 
-                let country = Country(name: name, code: code, phoneCode: phoneCode)
+                let country = CPVCountry(name: name, code: code, phoneCode: phoneCode)
                 countries.append(country)
             }
             
@@ -202,15 +202,15 @@ extension CountryPickerView {
         }
     }
     
-    public func getCountryByName(_ name: String) -> Country? {
+    public func getCountryByName(_ name: String) -> CPVCountry? {
         return countries.first(where: { $0.name == name })
     }
     
-    public func getCountryByPhoneCode(_ phoneCode: String) -> Country? {
+    public func getCountryByPhoneCode(_ phoneCode: String) -> CPVCountry? {
         return countries.first(where: { $0.phoneCode == phoneCode })
     }
     
-    public func getCountryByCode(_ code: String) -> Country? {
+    public func getCountryByCode(_ code: String) -> CPVCountry? {
         return countries.first(where: { $0.code == code })
     }
 }
@@ -219,7 +219,7 @@ extension CountryPickerView {
 // MARK:- An internal implementation of the CountryPickerViewDelegate.
 // Sets internal properties before calling external delegate.
 extension CountryPickerView {
-    func didSelectCountry(_ country: Country) {
+    func didSelectCountry(_ country: CPVCountry) {
         selectedCountry = country
         delegate?.countryPickerView(self, didSelectCountry: country)
     }

--- a/CountryPickerView/CountryPickerViewController.swift
+++ b/CountryPickerView/CountryPickerViewController.swift
@@ -11,10 +11,10 @@ import UIKit
 class CountryPickerViewController: UITableViewController {
     
     fileprivate var searchController: UISearchController?
-    fileprivate var searchResults = [Country]()
+    fileprivate var searchResults = [CPVCountry]()
     fileprivate var isSearchMode = false
     fileprivate var sectionsTitles = [String]()
-    fileprivate var countries = [String: [Country]]()
+    fileprivate var countries = [String: [CPVCountry]]()
     fileprivate var hasPreferredSection: Bool {
         return dataSource.preferredCountriesSectionTitle != nil &&
             dataSource.preferredCountries.count > 0
@@ -56,12 +56,12 @@ extension CountryPickerViewController {
                 header.insert(String(name[name.startIndex]))
             }
             
-            var data = [String: [Country]]()
+            var data = [String: [CPVCountry]]()
             
             countriesArray.forEach({
                 let name = $0.name
                 let index = String(name[name.startIndex])
-                var dictValue = data[index] ?? [Country]()
+                var dictValue = data[index] ?? [CPVCountry]()
                 dictValue.append($0)
                 
                 data[index] = dictValue
@@ -217,7 +217,7 @@ extension CountryPickerViewController: UISearchResultsUpdating {
             isSearchMode = true
             searchResults.removeAll()
             
-            var indexArray = [Country]()
+            var indexArray = [CPVCountry]()
             
             if showOnlyPreferredSection && hasPreferredSection,
                 let array = countries[dataSource.preferredCountriesSectionTitle!] {
@@ -283,7 +283,7 @@ class CountryPickerViewDataSourceInternal: CountryPickerViewDataSource {
         self.view = view
     }
     
-    var preferredCountries: [Country] {
+    var preferredCountries: [CPVCountry] {
         return view.dataSource?.preferredCountries(in: view) ?? preferredCountries(in: view)
     }
     

--- a/CountryPickerView/Delegate+DataSource.swift
+++ b/CountryPickerView/Delegate+DataSource.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public protocol CountryPickerViewDelegate: class {
     /// Called when the user selects a country from the list.
-    func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: Country)
+    func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: CPVCountry)
     
     /// Called before the internal UITableViewController is presented or pushed.
     /// If the UITableViewController is presented(not pushed), it is embedded in a UINavigationController.
@@ -25,7 +25,7 @@ public protocol CountryPickerViewDataSource: class {
     /// An array of countries you wish to show at the top of the list.
     /// This is useful if your app is targeted towards people in specific countries.
     /// - requires: The title for the section to be returned in `sectionTitleForPreferredCountries`
-    func preferredCountries(in countryPickerView: CountryPickerView) -> [Country]
+    func preferredCountries(in countryPickerView: CountryPickerView) -> [CPVCountry]
     
     /// The desired title for the preferred section.
     /// - **See:** `preferredCountries` method. Both are required for the section to be shown.
@@ -66,7 +66,7 @@ public protocol CountryPickerViewDataSource: class {
 // MARK:- CountryPickerViewDataSource default implementations
 public extension CountryPickerViewDataSource {
     
-    func preferredCountries(in countryPickerView: CountryPickerView) -> [Country] {
+    func preferredCountries(in countryPickerView: CountryPickerView) -> [CPVCountry] {
         return []
     }
     

--- a/CountryPickerViewDemo/CountryPickerViewDemo/DemoViewController.swift
+++ b/CountryPickerViewDemo/CountryPickerViewDemo/DemoViewController.swift
@@ -98,7 +98,7 @@ class DemoViewController: UITableViewController {
 }
 
 extension DemoViewController: CountryPickerViewDelegate {
-    func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: Country) {
+    func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: CPVCountry) {
         // Only countryPickerInternal has it's delegate set
         let title = "Selected Country"
         let message = "Name: \(country.name) \nCode: \(country.code) \nPhone: \(country.phoneCode)"
@@ -107,9 +107,9 @@ extension DemoViewController: CountryPickerViewDelegate {
 }
 
 extension DemoViewController: CountryPickerViewDataSource {
-    func preferredCountries(in countryPickerView: CountryPickerView) -> [Country] {
+    func preferredCountries(in countryPickerView: CountryPickerView) -> [CPVCountry] {
         if countryPickerView.tag == cpvMain.tag && showPreferredCountries.isOn {
-            var countries = [Country]()
+            var countries = [CPVCountry]()
             ["NG", "US", "GB"].forEach { code in
                 if let country = countryPickerView.getCountryByCode(code) {
                     countries.append(country)


### PR DESCRIPTION
Renamed Country to CPVCountry.

# Why
Country is a really generic name, and since Swift does not have namespacing, it should be quite common for a project to already have a Country Entity. I tested, and when you try to create the delegate, for example, you aren't able to because the two Country entities conflict.