### PR TITLE
Release version 2.2.1

### DIFF
--- a/CountryPickerView.podspec
+++ b/CountryPickerView.podspec
@@ -1,16 +1,17 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CountryPickerView"
-  spec.version      = "2.2.0"
+  spec.version      = "2.2.1"
   spec.summary      = "A simple, customizable view for selecting countries in iOS apps."
   spec.homepage     = "https://github.com/kizitonwose/CountryPickerView"
   spec.license      = "MIT"
   spec.author       = { "Kizito Nwose" => "kizitonwose@gmail.com" }
   spec.platform     = :ios, "8.0"
   spec.source       = { :git => "https://github.com/kizitonwose/CountryPickerView.git", :tag => spec.version }
-  spec.source_files  = "CountryPickerView/**/*.{swift,xib}"
+  spec.source_files  = "CountryPickerView/**/*.{swift}"
   spec.resource_bundles = {
-    'CountryPickerView' => ['CountryPickerView/Assets/CountryPickerView.bundle/*']
+    'CountryPickerView' => ['CountryPickerView/Assets/CountryPickerView.bundle/*',
+    'CountryPickerView/**/*.{xib}']
   }
   spec.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
 

--- a/CountryPickerView/CountryPickerView.swift
+++ b/CountryPickerView/CountryPickerView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+public typealias CPVCountry = Country
 
 public enum SearchBarPosition {
     case tableViewHeader, navigationBar, hidden

--- a/CountryPickerView/CountryPickerViewController.swift
+++ b/CountryPickerView/CountryPickerViewController.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class CountryPickerViewController: UITableViewController {
-    
-    fileprivate var searchController: UISearchController?
+public class CountryPickerViewController: UITableViewController {
+
+    public var searchController: UISearchController?
     fileprivate var searchResults = [Country]()
     fileprivate var isSearchMode = false
     fileprivate var sectionsTitles = [String]()
@@ -31,7 +31,7 @@ class CountryPickerViewController: UITableViewController {
     
     fileprivate var dataSource: CountryPickerViewDataSourceInternal!
     
-    override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         
         prepareTableItems()
@@ -113,14 +113,6 @@ extension CountryPickerViewController {
         searchController?.searchBar.delegate = self
         searchController?.delegate = self
 
-        if let searchBarBackgroundColor = dataSource.searchBarBackgroundColor {
-            searchController?.searchBar.backgroundColor = searchBarBackgroundColor
-        }
-
-        if let searchViewControllerBackgroundColor = dataSource.searchViewControllerBackgroundColor {
-            searchController?.view.backgroundColor = searchViewControllerBackgroundColor
-        }
-
         switch searchBarPosition {
         case .tableViewHeader: tableView.tableHeaderView = searchController?.searchBar
         case .navigationBar: navigationItem.titleView = searchController?.searchBar
@@ -136,15 +128,15 @@ extension CountryPickerViewController {
 //MARK:- UITableViewDataSource
 extension CountryPickerViewController {
     
-    override func numberOfSections(in tableView: UITableView) -> Int {
+    override public func numberOfSections(in tableView: UITableView) -> Int {
         return isSearchMode ? 1 : sectionsTitles.count
     }
     
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return isSearchMode ? searchResults.count : countries[sectionsTitles[section]]!.count
     }
     
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let identifier = String(describing: CountryTableViewCell.self)
         
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as? CountryTableViewCell
@@ -169,11 +161,11 @@ extension CountryPickerViewController {
         return cell
     }
     
-    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    override public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return isSearchMode ? nil : sectionsTitles[section]
     }
     
-    override func sectionIndexTitles(for tableView: UITableView) -> [String]? {
+    override public func sectionIndexTitles(for tableView: UITableView) -> [String]? {
         if isSearchMode {
             return nil
         } else {
@@ -184,7 +176,7 @@ extension CountryPickerViewController {
         }
     }
     
-    override func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
+    override public func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
         return sectionsTitles.index(of: title)!
     }
 }
@@ -192,7 +184,7 @@ extension CountryPickerViewController {
 //MARK:- UITableViewDelegate
 extension CountryPickerViewController {
 
-    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+    override public func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         if let header = view as? UITableViewHeaderFooterView {
             header.textLabel?.font = dataSource.sectionTitleLabelFont
             if let color = dataSource.sectionTitleTextColor {
@@ -201,7 +193,7 @@ extension CountryPickerViewController {
         }
     }
     
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let country = isSearchMode ? searchResults[indexPath.row]
             : countries[sectionsTitles[indexPath.section]]![indexPath.row]
@@ -222,7 +214,7 @@ extension CountryPickerViewController {
 
 // MARK:- UISearchResultsUpdating
 extension CountryPickerViewController: UISearchResultsUpdating {
-    func updateSearchResults(for searchController: UISearchController) {
+    public func updateSearchResults(for searchController: UISearchController) {
         isSearchMode = false
         if let text = searchController.searchBar.text, text.count > 0 {
             isSearchMode = true
@@ -339,14 +331,6 @@ class CountryPickerViewDataSourceInternal: CountryPickerViewDataSource {
     
     var searchBarPosition: SearchBarPosition {
         return view.dataSource?.searchBarPosition(in: view) ?? searchBarPosition(in: view)
-    }
-
-    var searchBarBackgroundColor: UIColor? {
-        return view.dataSource?.searchBarBackgroundColor(in: view)
-    }
-
-    var searchViewControllerBackgroundColor: UIColor? {
-        return view.dataSource?.searchViewControllerBackgroundColor(in: view)
     }
     
     var showPhoneCodeInList: Bool {

--- a/CountryPickerView/CountryPickerViewController.swift
+++ b/CountryPickerView/CountryPickerViewController.swift
@@ -113,6 +113,11 @@ extension CountryPickerViewController {
         searchController?.searchBar.delegate = self
         searchController?.delegate = self
 
+        if let color = dataSource.searchBarBackgroundColor {
+            searchController?.view.backgroundColor = color
+            searchController?.searchBar.backgroundColor = color
+        }
+
         switch searchBarPosition {
         case .tableViewHeader: tableView.tableHeaderView = searchController?.searchBar
         case .navigationBar: navigationItem.titleView = searchController?.searchBar
@@ -187,6 +192,9 @@ extension CountryPickerViewController {
     override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         if let header = view as? UITableViewHeaderFooterView {
             header.textLabel?.font = dataSource.sectionTitleLabelFont
+            if let color = dataSource.sectionTitleTextColor {
+                header.textLabel?.textColor = color
+            }
         }
     }
     
@@ -298,6 +306,10 @@ class CountryPickerViewDataSourceInternal: CountryPickerViewDataSource {
     var sectionTitleLabelFont: UIFont {
         return view.dataSource?.sectionTitleLabelFont(in: view) ?? sectionTitleLabelFont(in: view)
     }
+
+    var sectionTitleTextColor: UIColor? {
+        return view.dataSource?.sectionTitleTextColor(in: view)
+    }
     
     var cellLabelFont: UIFont {
         return view.dataSource?.cellLabelFont(in: view) ?? cellLabelFont(in: view)
@@ -324,6 +336,10 @@ class CountryPickerViewDataSourceInternal: CountryPickerViewDataSource {
     
     var searchBarPosition: SearchBarPosition {
         return view.dataSource?.searchBarPosition(in: view) ?? searchBarPosition(in: view)
+    }
+
+    var searchBarBackgroundColor: UIColor? {
+        return view.dataSource?.searchBarBackgroundColor(in: view)
     }
     
     var showPhoneCodeInList: Bool {

--- a/CountryPickerView/CountryPickerViewController.swift
+++ b/CountryPickerView/CountryPickerViewController.swift
@@ -113,9 +113,12 @@ extension CountryPickerViewController {
         searchController?.searchBar.delegate = self
         searchController?.delegate = self
 
-        if let color = dataSource.searchBarBackgroundColor {
-            searchController?.view.backgroundColor = color
-            searchController?.searchBar.backgroundColor = color
+        if let searchBarBackgroundColor = dataSource.searchBarBackgroundColor {
+            searchController?.searchBar.backgroundColor = searchBarBackgroundColor
+        }
+
+        if let searchViewControllerBackgroundColor = dataSource.searchViewControllerBackgroundColor {
+            searchController?.view.backgroundColor = searchViewControllerBackgroundColor
         }
 
         switch searchBarPosition {
@@ -340,6 +343,10 @@ class CountryPickerViewDataSourceInternal: CountryPickerViewDataSource {
 
     var searchBarBackgroundColor: UIColor? {
         return view.dataSource?.searchBarBackgroundColor(in: view)
+    }
+
+    var searchViewControllerBackgroundColor: UIColor? {
+        return view.dataSource?.searchViewControllerBackgroundColor(in: view)
     }
     
     var showPhoneCodeInList: Bool {

--- a/CountryPickerView/CountryPickerViewController.swift
+++ b/CountryPickerView/CountryPickerViewController.swift
@@ -156,6 +156,9 @@ extension CountryPickerViewController {
         
         cell.textLabel?.text = name
         cell.textLabel?.font = dataSource.cellLabelFont
+        if let color = dataSource.cellLabelColor {
+            cell.textLabel?.textColor = color
+        }
         cell.accessoryType = country == countryPickerView.selectedCountry ? .checkmark : .none
         cell.separatorInset = .zero
         return cell
@@ -187,7 +190,7 @@ extension CountryPickerViewController {
     override public func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         if let header = view as? UITableViewHeaderFooterView {
             header.textLabel?.font = dataSource.sectionTitleLabelFont
-            if let color = dataSource.sectionTitleTextColor {
+            if let color = dataSource.sectionTitleLabelColor {
                 header.textLabel?.textColor = color
             }
         }
@@ -302,12 +305,16 @@ class CountryPickerViewDataSourceInternal: CountryPickerViewDataSource {
         return view.dataSource?.sectionTitleLabelFont(in: view) ?? sectionTitleLabelFont(in: view)
     }
 
-    var sectionTitleTextColor: UIColor? {
-        return view.dataSource?.sectionTitleTextColor(in: view)
+    var sectionTitleLabelColor: UIColor? {
+        return view.dataSource?.sectionTitleLabelColor(in: view)
     }
     
     var cellLabelFont: UIFont {
         return view.dataSource?.cellLabelFont(in: view) ?? cellLabelFont(in: view)
+    }
+    
+    var cellLabelColor: UIColor? {
+        return view.dataSource?.cellLabelColor(in: view)
     }
     
     var cellImageViewSize: CGSize {

--- a/CountryPickerView/CountryPickerViewController.swift
+++ b/CountryPickerView/CountryPickerViewController.swift
@@ -232,7 +232,7 @@ extension CountryPickerViewController: UISearchResultsUpdating {
                 indexArray = array
             }
 
-            searchResults.append(contentsOf: indexArray.filter({ $0.name.hasPrefix(text) }))
+            searchResults.append(contentsOf: indexArray.filter({ $0.name.lowercased().hasPrefix(text.lowercased()) }))
         }
         tableView.reloadData()
     }

--- a/CountryPickerView/Delegate+DataSource.swift
+++ b/CountryPickerView/Delegate+DataSource.swift
@@ -40,8 +40,7 @@ public protocol CountryPickerViewDataSource: class {
     /// Default value is UIFont.boldSystemFont(ofSize: 17)
     func sectionTitleLabelFont(in countryPickerView: CountryPickerView) -> UIFont
 
-    /// The desired text color for the section title labels on list. The default is the tableViewCell
-    /// default text color.
+    /// The desired text color for the section title labels on the list.
     func sectionTitleTextColor(in countryPickerView: CountryPickerView) -> UIColor?
     
     /// The desired font for the cell labels on the list. Can be used to configure the text size.

--- a/CountryPickerView/Delegate+DataSource.swift
+++ b/CountryPickerView/Delegate+DataSource.swift
@@ -12,13 +12,15 @@ public protocol CountryPickerViewDelegate: class {
     /// Called when the user selects a country from the list.
     func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: Country)
     
-    /// Called before the internal UITableViewController is presented or pushed.
-    /// If the UITableViewController is presented(not pushed), it is embedded in a UINavigationController.
-    func countryPickerView(_ countryPickerView: CountryPickerView, willShow viewController: UITableViewController)
+    /// Called before the internal CountryPickerViewController is presented or pushed.
+    /// If the CountryPickerViewController is presented(not pushed), it is embedded in a UINavigationController.
+    /// The CountryPickerViewController is a UITableViewController subclass.
+    func countryPickerView(_ countryPickerView: CountryPickerView, willShow viewController: CountryPickerViewController)
     
-    /// Called after the internal UITableViewController is presented or pushed.
-    /// If the UITableViewController is presented(not pushed), it is embedded in a UINavigationController.
-    func countryPickerView(_ countryPickerView: CountryPickerView, didShow viewController: UITableViewController)
+    /// Called after the internal CountryPickerViewController is presented or pushed.
+    /// If the CountryPickerViewController is presented(not pushed), it is embedded in a UINavigationController.
+    /// The CountryPickerViewController is a UITableViewController subclass.
+    func countryPickerView(_ countryPickerView: CountryPickerView, didShow viewController: CountryPickerViewController)
 }
 
 public protocol CountryPickerViewDataSource: class {
@@ -61,13 +63,6 @@ public protocol CountryPickerViewDataSource: class {
     
     /// The desired position for the search bar.
     func searchBarPosition(in countryPickerView: CountryPickerView) -> SearchBarPosition
-
-    /// The desired background color for the search bar. The default is the default searchBar background color.
-    func searchBarBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor?
-
-    /// The desired background color for the UISearchViewController view's background. The default is the default
-    /// UISearchViewController view background color.
-    func searchViewControllerBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor?
     
     /// This determines if a country's phone code is shown alongside the country's name on the list.
     /// e.g Nigeria (+234)
@@ -119,14 +114,6 @@ public extension CountryPickerViewDataSource {
     
     func searchBarPosition(in countryPickerView: CountryPickerView) -> SearchBarPosition {
         return .tableViewHeader
-    }
-
-    func searchBarBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor? {
-        return nil
-    }
-
-    func searchViewControllerBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor? {
-        return nil
     }
     
     func showPhoneCodeInList(in countryPickerView: CountryPickerView) -> Bool {

--- a/CountryPickerView/Delegate+DataSource.swift
+++ b/CountryPickerView/Delegate+DataSource.swift
@@ -63,8 +63,11 @@ public protocol CountryPickerViewDataSource: class {
     func searchBarPosition(in countryPickerView: CountryPickerView) -> SearchBarPosition
 
     /// The desired background color for the search bar. The default is the default searchBar background color.
-    /// It also sets the background color of the UISearchViewController view to the same color if set.
     func searchBarBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor?
+
+    /// The desired background color for the UISearchViewController view's background. The default is the default
+    /// UISearchViewController view background color.
+    func searchViewControllerBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor?
     
     /// This determines if a country's phone code is shown alongside the country's name on the list.
     /// e.g Nigeria (+234)
@@ -119,6 +122,10 @@ public extension CountryPickerViewDataSource {
     }
 
     func searchBarBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor? {
+        return nil
+    }
+
+    func searchViewControllerBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor? {
         return nil
     }
     

--- a/CountryPickerView/Delegate+DataSource.swift
+++ b/CountryPickerView/Delegate+DataSource.swift
@@ -41,11 +41,14 @@ public protocol CountryPickerViewDataSource: class {
     func sectionTitleLabelFont(in countryPickerView: CountryPickerView) -> UIFont
 
     /// The desired text color for the section title labels on the list.
-    func sectionTitleTextColor(in countryPickerView: CountryPickerView) -> UIColor?
+    func sectionTitleLabelColor(in countryPickerView: CountryPickerView) -> UIColor?
     
     /// The desired font for the cell labels on the list. Can be used to configure the text size.
     /// Default value is UIFont.systemFont(ofSize: 17)
     func cellLabelFont(in countryPickerView: CountryPickerView) -> UIFont
+    
+    /// The desired text color for the country names on the list.
+    func cellLabelColor(in countryPickerView: CountryPickerView) -> UIColor?
     
     /// The desired size for the flag images on the list.
     func cellImageViewSize(in countryPickerView: CountryPickerView) -> CGSize
@@ -87,12 +90,16 @@ public extension CountryPickerViewDataSource {
         return UIFont.boldSystemFont(ofSize: 17)
     }
 
-    func sectionTitleTextColor(in countryPickerView: CountryPickerView) -> UIColor? {
+    func sectionTitleLabelColor(in countryPickerView: CountryPickerView) -> UIColor? {
         return nil
     }
     
     func cellLabelFont(in countryPickerView: CountryPickerView) -> UIFont {
         return UIFont.systemFont(ofSize: 17)
+    }
+    
+    func cellLabelColor(in countryPickerView: CountryPickerView) -> UIColor? {
+        return nil
     }
     
     func cellImageViewCornerRadius(in countryPickerView: CountryPickerView) -> CGFloat {

--- a/CountryPickerView/Delegate+DataSource.swift
+++ b/CountryPickerView/Delegate+DataSource.swift
@@ -37,6 +37,10 @@ public protocol CountryPickerViewDataSource: class {
     /// The desired font for the section title labels on the list. Can be used to configure the text size.
     /// Default value is UIFont.boldSystemFont(ofSize: 17)
     func sectionTitleLabelFont(in countryPickerView: CountryPickerView) -> UIFont
+
+    /// The desired text color for the section title labels on list. The default is the tableViewCell
+    /// default text color.
+    func sectionTitleTextColor(in countryPickerView: CountryPickerView) -> UIColor?
     
     /// The desired font for the cell labels on the list. Can be used to configure the text size.
     /// Default value is UIFont.systemFont(ofSize: 17)
@@ -57,6 +61,10 @@ public protocol CountryPickerViewDataSource: class {
     
     /// The desired position for the search bar.
     func searchBarPosition(in countryPickerView: CountryPickerView) -> SearchBarPosition
+
+    /// The desired background color for the search bar. The default is the default searchBar background color.
+    /// It also sets the background color of the UISearchViewController view to the same color if set.
+    func searchBarBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor?
     
     /// This determines if a country's phone code is shown alongside the country's name on the list.
     /// e.g Nigeria (+234)
@@ -81,6 +89,10 @@ public extension CountryPickerViewDataSource {
     func sectionTitleLabelFont(in countryPickerView: CountryPickerView) -> UIFont {
         return UIFont.boldSystemFont(ofSize: 17)
     }
+
+    func sectionTitleTextColor(in countryPickerView: CountryPickerView) -> UIColor? {
+        return nil
+    }
     
     func cellLabelFont(in countryPickerView: CountryPickerView) -> UIFont {
         return UIFont.systemFont(ofSize: 17)
@@ -104,6 +116,10 @@ public extension CountryPickerViewDataSource {
     
     func searchBarPosition(in countryPickerView: CountryPickerView) -> SearchBarPosition {
         return .tableViewHeader
+    }
+
+    func searchBarBackgroundColor(in countryPickerView: CountryPickerView) -> UIColor? {
+        return nil
     }
     
     func showPhoneCodeInList(in countryPickerView: CountryPickerView) -> Bool {

--- a/CountryPickerView/Delegate+DataSource.swift
+++ b/CountryPickerView/Delegate+DataSource.swift
@@ -124,12 +124,12 @@ public extension CountryPickerViewDataSource {
 // MARK:- CountryPickerViewDelegate default implementations
 public extension CountryPickerViewDelegate {
 
-    func countryPickerView(_ countryPickerView: CountryPickerView, willShow viewController: UITableViewController) {
-        
+    func countryPickerView(_ countryPickerView: CountryPickerView,
+                           willShow viewController: CountryPickerViewController) {
     }
     
-    func countryPickerView(_ countryPickerView: CountryPickerView, didShow viewController: UITableViewController) {
-
+    func countryPickerView(_ countryPickerView: CountryPickerView,
+                           didShow viewController: CountryPickerViewController) {
     }
 
 }

--- a/CountryPickerView/NibView.swift
+++ b/CountryPickerView/NibView.swift
@@ -31,8 +31,10 @@ public class NibView: UIView {
     }
     
     fileprivate func loadViewFromNib() -> UIView {
-        let bundle = Bundle(for: type(of: self))
-        let nib = UINib(nibName: String(describing: type(of: self)), bundle: bundle)
+        let podBundle = Bundle(for: type(of: self))
+        let nibBundleURL = podBundle.url(forResource: "CountryPickerView", withExtension: "bundle")!
+        let nibBundle = Bundle(url: nibBundleURL)
+        let nib = UINib(nibName: String(describing: type(of: self)), bundle: nibBundle)
         let nibView = nib.instantiate(withOwner: self, options: nil).first as! UIView
         
         return nibView

--- a/CountryPickerViewDemo/Podfile.lock
+++ b/CountryPickerViewDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CountryPickerView (2.2.0)
+  - CountryPickerView (2.2.1)
 
 DEPENDENCIES:
   - CountryPickerView (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CountryPickerView: 54e390a033ed5892bfddd62ef0efaa450f35eb27
+  CountryPickerView: f9dbc3e206e6091375b543d527f6ecffe132345a
 
 PODFILE CHECKSUM: 649829ad9a32abd953e33364dc48a4a40a615047
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![License](https://img.shields.io/badge/License-MIT-8D6E63.svg)](https://github.com/kizitonwose/CountryPickerView/blob/master/LICENSE.md)
 
-CountryPickerView is a simple, customizable view for selecting countries in iOS apps. 
+CountryPickerView is a simple, customizable view for selecting countries in iOS apps.
 
 You can clone/download the repository and run the [demo project](https://github.com/kizitonwose/CountryPickerView/tree/master/CountryPickerViewDemo) to see CountryPickerView in action. First run `pod install` from the CountryPickerViewDemo directory.
 
-<img align="left" src="https://raw.githubusercontent.com/kizitonwose/CountryPickerView/master/CountryPickerViewDemo/Screenshots/1.png" width="300"> 
-<img src="https://raw.githubusercontent.com/kizitonwose/CountryPickerView/master/CountryPickerViewDemo/Screenshots/2.png" width="300"> 
+<img align="left" src="https://raw.githubusercontent.com/kizitonwose/CountryPickerView/master/CountryPickerViewDemo/Screenshots/1.png" width="300">
+<img src="https://raw.githubusercontent.com/kizitonwose/CountryPickerView/master/CountryPickerViewDemo/Screenshots/2.png" width="300">
 
-<img align="left" src="https://raw.githubusercontent.com/kizitonwose/CountryPickerView/master/CountryPickerViewDemo/Screenshots/3.png" width="300"> 
+<img align="left" src="https://raw.githubusercontent.com/kizitonwose/CountryPickerView/master/CountryPickerViewDemo/Screenshots/3.png" width="300">
 <img src="https://raw.githubusercontent.com/kizitonwose/CountryPickerView/master/CountryPickerViewDemo/Screenshots/4.png" width="300">
 
 
@@ -63,7 +63,7 @@ import CountryPickerView
 let cpv = CountryPickerView(frame: /**Desired frame**/)
 ```
 
-To get the selected country from your `CountryPickerView` instance at any time, use the `selectedCountry` property. 
+To get the selected country from your `CountryPickerView` instance at any time, use the `selectedCountry` property.
 
 ```swift
 let country = cpv.selectedCountry
@@ -84,39 +84,41 @@ class DemoViewController: UIViewController, CountryPickerViewDelegate, CountryPi
 
     override func viewDidLoad() {
         super.viewDidLoad()
-    
+
         countryPickerView.delegate = self
         countryPickerView.dataSource = self
-        
+
         /*** Direct customizations on CountryPickerView instance ***/
-        
+
         // Show the selected country's phone(e.g +234) code on the view
         countryPickerView.showPhoneCodeInView = true
-        
+
         // Show the selected country's iso code(e.g NG) on the view
         countryPickerView.showCountryCodeInView = true
     }
-    
+
 }
 ```
 
 #### CountryPickerViewDelegate
 - Called when the user selects a country from the list or when you manually set the `selectedCountry` property of the `CountryPickerView`
   ```swift
-    func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: Country) 
+    func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: Country)
   ```
 
-- Called before the internal UITableViewController is presented or pushed.
+- Called before the CountryPickerViewController is presented or pushed. The CountryPickerViewController is a UITableViewController subclass.
   ```swift
-    func countryPickerView(_ countryPickerView: CountryPickerView, willShow viewController: UITableViewController) 
+    func countryPickerView(_ countryPickerView: CountryPickerView, willShow viewController: CountryPickerViewController)
   ```
 
-- Called after the internal UITableViewController is presented or pushed.
+- Called after the CountryPickerViewController is presented or pushed. The CountryPickerViewController is a UITableViewController subclass.
   ```swift
-    func countryPickerView(_ countryPickerView: CountryPickerView, didShow viewController: UITableViewController) 
+    func countryPickerView(_ countryPickerView: CountryPickerView, didShow viewController: CountryPickerViewController)
   ```
 
-**Note:** `willShow` and `didShow` delegate methods are optional. Also, if the UITableViewController is presented(not pushed), it is embedded in a UINavigationController.
+**Note:** `willShow` and `didShow` delegate methods are optional. Also, if the CountryPickerViewController is presented(not pushed), it is embedded in a UINavigationController.
+
+**Note 2:** The CountryPickerViewController is made public in the `willShow` and `didShow` to be able to customize its appearance. Moreover, you can also customize the `UISearchController`'s appearance and the `UISearchBar`'s appearance by accessing the public `searchController` property on the `CountryPickerViewController`.
 
 #### CountryPickerViewDataSource
 The datasource methods define the internal(country list) ViewController's behavior. Run the demo project to play around with the options. All methods are optional.
@@ -124,45 +126,45 @@ The datasource methods define the internal(country list) ViewController's behavi
 - An array of countries you wish to show at the top of the list. This is useful if your app is targeted towards people in specific countries.
   ```swift
     func preferredCountries(in countryPickerView: CountryPickerView) -> [Country]
-  ``` 
-  
-- The desired title for the preferred section. 
+  ```
+
+- The desired title for the preferred section.
   ```swift  
     func sectionTitleForPreferredCountries(in countryPickerView: CountryPickerView) -> String?
   ```
-  **Note:** You have to return a non-empty array of countries from `preferredCountries(in countryPickerView: CountryPickerView)` as well as this section title if you wish to show preferred countries on the list. Returning only the array or title will not work. 
-  
+  **Note:** You have to return a non-empty array of countries from `preferredCountries(in countryPickerView: CountryPickerView)` as well as this section title if you wish to show preferred countries on the list. Returning only the array or title will not work.
+
 - Show **ONLY** the preferred countries section on the list. Default value is `false`
   ```swift  
     func showOnlyPreferredSection(in countryPickerView: CountryPickerView) -> Bool
-  ``` 
-  Return `true` to hide the internal list so your users can only choose from the preferred countries list. 
- 
+  ```
+  Return `true` to hide the internal list so your users can only choose from the preferred countries list.
+
 - The desired font for the section title labels on the list. Can be used to configure the text size.
   ```swift  
     func sectionTitleLabelFont(in countryPickerView: CountryPickerView) -> UIFont
-  ``` 
-  
+  ```
+
 - The desired font for the cell labels on the list. Can be used to configure the text size.
   ```swift  
     func cellLabelFont(in countryPickerView: CountryPickerView) -> UIFont
-  ``` 
+  ```
 
 - The desired size for the flag images on the list.
   ```swift  
     func cellImageViewSize(in countryPickerView: CountryPickerView) -> CGSize
-  ``` 
+  ```
 
 - The desired corner radius for the flag images on the list.
   ```swift  
     func cellImageViewCornerRadius(in countryPickerView: CountryPickerView) -> CGFloat
-  ``` 
+  ```
 
 - The navigation item title when the internal view controller is pushed/presented. Default value is `nil`
   ```swift   
     func navigationTitle(in countryPickerView: CountryPickerView) -> String?
-  ``` 
- 
+  ```
+
 - A navigation item button to be used if the internal view controller is presented(not pushed). If nil is returned, a default "Close" button is used. This method only enables you return a button customized the way you want. Default value is `nil`
   ```swift    
     func closeButtonNavigationItem(in countryPickerView: CountryPickerView) -> UIBarButtonItem?
@@ -174,15 +176,15 @@ The datasource methods define the internal(country list) ViewController's behavi
     func searchBarPosition(in countryPickerView: CountryPickerView) -> SearchBarPosition
   ```
   Possible values are: `.tableViewHeader`, `.navigationBar` and `.hidden`
- 
+
 - Show the phone code alongside the country name on the list. e.g Nigeria (+234). Default value is `false`
   ```swift    
-    func showPhoneCodeInList(in countryPickerView: CountryPickerView) -> Bool 
+    func showPhoneCodeInList(in countryPickerView: CountryPickerView) -> Bool
   ```
 
 ### Using CountryPickerView with UITextField
 
-A good use case for `CountryPickerView` is when used as the left view of a phone number input field. 
+A good use case for `CountryPickerView` is when used as the left view of a phone number input field.
 
 ```swift
 class DemoViewController: UIViewController {
@@ -191,7 +193,7 @@ class DemoViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         let cpv = CountryPickerView(frame: CGRect(x: 0, y: 0, width: 120, height: 20))
         phoneNumberField.leftView = cpv
         phoneNumberField.leftViewMode = .always
@@ -202,7 +204,7 @@ This means your users do not have to worry about entering the country's phone co
 
 ### Using the internal picker independently
 
-If for any reason you do not want to show the default view or have your own implementation for showing country information, you can still use the internal picker to allow your users select countries from the list by calling the method `showCountriesList(from: UIViewController)` on a `CountryPickerView` instance. 
+If for any reason you do not want to show the default view or have your own implementation for showing country information, you can still use the internal picker to allow your users select countries from the list by calling the method `showCountriesList(from: UIViewController)` on a `CountryPickerView` instance.
 
 It's important to keep a field reference to the `CountryPickerView` instance else it will be garbage collected and any attempt to use it will result to a crash.
 
@@ -215,15 +217,15 @@ class DemoViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-    
+
     @IBAction func buttonPressed(_ sender: Any) {
         countryPickerView.showCountriesList(from: self)
     }
 }
 ```
-In the example above, calling `countryPickerView.showCountriesList(from: self)` will result in the internal picker view controller being presented in its own navigation stack because `DemoViewController` is not a navigation controller. 
+In the example above, calling `countryPickerView.showCountriesList(from: self)` will result in the internal picker view controller being presented in its own navigation stack because `DemoViewController` is not a navigation controller.
 
-If you already have a navigation stack, you can push the internal picker view controller onto that stack by calling `countryPickerView.showCountriesList(from: self.navigationController!)` or do it the safe way: 
+If you already have a navigation stack, you can push the internal picker view controller onto that stack by calling `countryPickerView.showCountriesList(from: self.navigationController!)` or do it the safe way:
 
 ```swift
 if let nav = self.navigationController {

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ class DemoViewController: UIViewController, CountryPickerViewDelegate, CountryPi
     func countryPickerView(_ countryPickerView: CountryPickerView, didShow viewController: CountryPickerViewController)
   ```
 
-**Note:** `willShow` and `didShow` delegate methods are optional. Also, if the CountryPickerViewController is presented(not pushed), it is embedded in a UINavigationController.
+**Note:** `willShow` and `didShow` delegate methods are optional. If the CountryPickerViewController is presented(not pushed), it is embedded in a UINavigationController.
+The `CountryPickerViewController` class is made available so you can customize its appearance if needed. You can also access the public `searchController(UISearchController)` property in the `CountryPickerViewController` for customization.
 
-**Note 2:** The CountryPickerViewController is made public in the `willShow` and `didShow` to be able to customize its appearance. Moreover, you can also customize the `UISearchController`'s appearance and the `UISearchBar`'s appearance by accessing the public `searchController` property on the `CountryPickerViewController`.
 
 #### CountryPickerViewDataSource
 The datasource methods define the internal(country list) ViewController's behavior. Run the demo project to play around with the options. All methods are optional.

--- a/README.md
+++ b/README.md
@@ -102,21 +102,32 @@ class DemoViewController: UIViewController, CountryPickerViewDelegate, CountryPi
 
 #### CountryPickerViewDelegate
 - Called when the user selects a country from the list or when you manually set the `selectedCountry` property of the `CountryPickerView`
+
   ```swift
     func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: Country)
   ```
 
 - Called before the CountryPickerViewController is presented or pushed. The CountryPickerViewController is a UITableViewController subclass.
+  
   ```swift
     func countryPickerView(_ countryPickerView: CountryPickerView, willShow viewController: CountryPickerViewController)
   ```
 
 - Called after the CountryPickerViewController is presented or pushed. The CountryPickerViewController is a UITableViewController subclass.
+  
   ```swift
     func countryPickerView(_ countryPickerView: CountryPickerView, didShow viewController: CountryPickerViewController)
   ```
 
-**Note:** `willShow` and `didShow` delegate methods are optional. If the CountryPickerViewController is presented(not pushed), it is embedded in a UINavigationController.
+**Note: If you already have a `Country` class or struct in your project then implementing the `didSelectCountry` delegate method can cause a compile error with a message saying that your conforming class does not comform to the `CountryPickerViewDelegate` protocol. This is because Xcode can't figure out which Country model to use in the method. The solution is to replace the `Country` in the method signature with the typealais `CPVCountry`, your delegate method should now look like this:**
+
+```swift
+func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: CPVCountry)
+``` 
+  
+  You can also use `CPVCountry` as a replacement for the framework's `Country` model in other parts of your project.
+
+Also, `willShow` and `didShow` delegate methods are optional. If the CountryPickerViewController is presented(not pushed), it is embedded in a UINavigationController.
 The `CountryPickerViewController` class is made available so you can customize its appearance if needed. You can also access the public `searchController(UISearchController)` property in the `CountryPickerViewController` for customization.
 
 
@@ -124,60 +135,83 @@ The `CountryPickerViewController` class is made available so you can customize i
 The datasource methods define the internal(country list) ViewController's behavior. Run the demo project to play around with the options. All methods are optional.
 
 - An array of countries you wish to show at the top of the list. This is useful if your app is targeted towards people in specific countries.
+  
   ```swift
     func preferredCountries(in countryPickerView: CountryPickerView) -> [Country]
   ```
 
 - The desired title for the preferred section.
+  
   ```swift  
     func sectionTitleForPreferredCountries(in countryPickerView: CountryPickerView) -> String?
   ```
   **Note:** You have to return a non-empty array of countries from `preferredCountries(in countryPickerView: CountryPickerView)` as well as this section title if you wish to show preferred countries on the list. Returning only the array or title will not work.
 
 - Show **ONLY** the preferred countries section on the list. Default value is `false`
+  
   ```swift  
     func showOnlyPreferredSection(in countryPickerView: CountryPickerView) -> Bool
   ```
   Return `true` to hide the internal list so your users can only choose from the preferred countries list.
 
 - The desired font for the section title labels on the list. Can be used to configure the text size.
+  
   ```swift  
     func sectionTitleLabelFont(in countryPickerView: CountryPickerView) -> UIFont
   ```
 
+- The desired text color for the section title labels on the list.
+  
+  ```swift  
+     func sectionTitleLabelColor(in countryPickerView: CountryPickerView) -> UIColor?
+  ```
+
 - The desired font for the cell labels on the list. Can be used to configure the text size.
+  
   ```swift  
     func cellLabelFont(in countryPickerView: CountryPickerView) -> UIFont
   ```
 
+- The desired text color for the country names on the list.
+  
+  ```swift  
+    func cellLabelColor(in countryPickerView: CountryPickerView) -> UIColor?
+  ```
+
 - The desired size for the flag images on the list.
+  
   ```swift  
     func cellImageViewSize(in countryPickerView: CountryPickerView) -> CGSize
   ```
 
 - The desired corner radius for the flag images on the list.
+  
   ```swift  
     func cellImageViewCornerRadius(in countryPickerView: CountryPickerView) -> CGFloat
   ```
 
 - The navigation item title when the internal view controller is pushed/presented. Default value is `nil`
+  
   ```swift   
     func navigationTitle(in countryPickerView: CountryPickerView) -> String?
   ```
 
 - A navigation item button to be used if the internal view controller is presented(not pushed). If nil is returned, a default "Close" button is used. This method only enables you return a button customized the way you want. Default value is `nil`
+  
   ```swift    
     func closeButtonNavigationItem(in countryPickerView: CountryPickerView) -> UIBarButtonItem?
   ```
   **Note:** Any `target` or `action` associated with this button will be replaced as this button's sole purpose is to close the internal view controller.
 
 - Desired position for the search bar. Default value is `.tableViewHeader`
+  
   ```swift    
     func searchBarPosition(in countryPickerView: CountryPickerView) -> SearchBarPosition
   ```
   Possible values are: `.tableViewHeader`, `.navigationBar` and `.hidden`
 
 - Show the phone code alongside the country name on the list. e.g Nigeria (+234). Default value is `false`
+  
   ```swift    
     func showPhoneCodeInList(in countryPickerView: CountryPickerView) -> Bool
   ```

--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@ class DemoViewController: UIViewController, CountryPickerViewDelegate, CountryPi
 - Called when the user selects a country from the list or when you manually set the `selectedCountry` property of the `CountryPickerView`
 
   ```swift
-    func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: Country)
+  func countryPickerView(_ countryPickerView: CountryPickerView, didSelectCountry country: Country)
   ```
 
 - Called before the CountryPickerViewController is presented or pushed. The CountryPickerViewController is a UITableViewController subclass.
   
   ```swift
-    func countryPickerView(_ countryPickerView: CountryPickerView, willShow viewController: CountryPickerViewController)
+  func countryPickerView(_ countryPickerView: CountryPickerView, willShow viewController: CountryPickerViewController)
   ```
 
 - Called after the CountryPickerViewController is presented or pushed. The CountryPickerViewController is a UITableViewController subclass.
   
   ```swift
-    func countryPickerView(_ countryPickerView: CountryPickerView, didShow viewController: CountryPickerViewController)
+  func countryPickerView(_ countryPickerView: CountryPickerView, didShow viewController: CountryPickerViewController)
   ```
 
 **Note: If you already have a `Country` class or struct in your project then implementing the `didSelectCountry` delegate method can cause a compile error with a message saying that your conforming class does not comform to the `CountryPickerViewDelegate` protocol. This is because Xcode can't figure out which Country model to use in the method. The solution is to replace the `Country` in the method signature with the typealais `CPVCountry`, your delegate method should now look like this:**
@@ -137,83 +137,83 @@ The datasource methods define the internal(country list) ViewController's behavi
 - An array of countries you wish to show at the top of the list. This is useful if your app is targeted towards people in specific countries.
   
   ```swift
-    func preferredCountries(in countryPickerView: CountryPickerView) -> [Country]
+  func preferredCountries(in countryPickerView: CountryPickerView) -> [Country]
   ```
 
 - The desired title for the preferred section.
   
   ```swift  
-    func sectionTitleForPreferredCountries(in countryPickerView: CountryPickerView) -> String?
+  func sectionTitleForPreferredCountries(in countryPickerView: CountryPickerView) -> String?
   ```
   **Note:** You have to return a non-empty array of countries from `preferredCountries(in countryPickerView: CountryPickerView)` as well as this section title if you wish to show preferred countries on the list. Returning only the array or title will not work.
 
 - Show **ONLY** the preferred countries section on the list. Default value is `false`
   
   ```swift  
-    func showOnlyPreferredSection(in countryPickerView: CountryPickerView) -> Bool
+  func showOnlyPreferredSection(in countryPickerView: CountryPickerView) -> Bool
   ```
   Return `true` to hide the internal list so your users can only choose from the preferred countries list.
 
 - The desired font for the section title labels on the list. Can be used to configure the text size.
   
   ```swift  
-    func sectionTitleLabelFont(in countryPickerView: CountryPickerView) -> UIFont
+  func sectionTitleLabelFont(in countryPickerView: CountryPickerView) -> UIFont
   ```
 
 - The desired text color for the section title labels on the list.
   
   ```swift  
-     func sectionTitleLabelColor(in countryPickerView: CountryPickerView) -> UIColor?
+  func sectionTitleLabelColor(in countryPickerView: CountryPickerView) -> UIColor?
   ```
 
 - The desired font for the cell labels on the list. Can be used to configure the text size.
   
   ```swift  
-    func cellLabelFont(in countryPickerView: CountryPickerView) -> UIFont
+  func cellLabelFont(in countryPickerView: CountryPickerView) -> UIFont
   ```
 
 - The desired text color for the country names on the list.
   
   ```swift  
-    func cellLabelColor(in countryPickerView: CountryPickerView) -> UIColor?
+  func cellLabelColor(in countryPickerView: CountryPickerView) -> UIColor?
   ```
 
 - The desired size for the flag images on the list.
   
   ```swift  
-    func cellImageViewSize(in countryPickerView: CountryPickerView) -> CGSize
+  func cellImageViewSize(in countryPickerView: CountryPickerView) -> CGSize
   ```
 
 - The desired corner radius for the flag images on the list.
   
   ```swift  
-    func cellImageViewCornerRadius(in countryPickerView: CountryPickerView) -> CGFloat
+  func cellImageViewCornerRadius(in countryPickerView: CountryPickerView) -> CGFloat
   ```
 
 - The navigation item title when the internal view controller is pushed/presented. Default value is `nil`
   
   ```swift   
-    func navigationTitle(in countryPickerView: CountryPickerView) -> String?
+  func navigationTitle(in countryPickerView: CountryPickerView) -> String?
   ```
 
 - A navigation item button to be used if the internal view controller is presented(not pushed). If nil is returned, a default "Close" button is used. This method only enables you return a button customized the way you want. Default value is `nil`
   
   ```swift    
-    func closeButtonNavigationItem(in countryPickerView: CountryPickerView) -> UIBarButtonItem?
+  func closeButtonNavigationItem(in countryPickerView: CountryPickerView) -> UIBarButtonItem?
   ```
   **Note:** Any `target` or `action` associated with this button will be replaced as this button's sole purpose is to close the internal view controller.
 
 - Desired position for the search bar. Default value is `.tableViewHeader`
   
   ```swift    
-    func searchBarPosition(in countryPickerView: CountryPickerView) -> SearchBarPosition
+  func searchBarPosition(in countryPickerView: CountryPickerView) -> SearchBarPosition
   ```
   Possible values are: `.tableViewHeader`, `.navigationBar` and `.hidden`
 
 - Show the phone code alongside the country name on the list. e.g Nigeria (+234). Default value is `false`
   
   ```swift    
-    func showPhoneCodeInList(in countryPickerView: CountryPickerView) -> Bool
+  func showPhoneCodeInList(in countryPickerView: CountryPickerView) -> Bool
   ```
 
 ### Using CountryPickerView with UITextField


### PR DESCRIPTION
- Add `CPVCountry` typealias to be used if a project already has a `Country` class or struct.
- Convert search query to lower case before comparing with country names.
- Add delegate methods for customizing cell label and section title label colors.
- Make `CountryPickerViewController` public to ease customization.