### PR TITLE
Fixed The name of the Iran country

### DIFF
--- a/CountryPickerView/Assets/CountryPickerView.bundle/Data/CountryCodes.json
+++ b/CountryPickerView/Assets/CountryPickerView.bundle/Data/CountryCodes.json
@@ -495,7 +495,7 @@
 "code": "ID"
 },
 {
-"name": "Iran, Islamic Republic of Persian Gulf",
+"name": "Iran",
 "dial_code": "+98",
 "code": "IR"
 },


### PR DESCRIPTION
I changed the name of Iran country from "Iran, Islamic Republic of Persian Gulf" to "Iran" in CountryCodes.json file.